### PR TITLE
sheet_index parameter for check_retrieved script

### DIFF
--- a/check_retrieved.py
+++ b/check_retrieved.py
@@ -3,12 +3,13 @@ import sys
 import pandas as pd
 
 def main():
-    if len(sys.argv) != 3:
-        print("Usage: python check_retrieved.py directory/of/pdb_files file.xlsx")
+    if len(sys.argv) < 3 or len(sys.argv) > 4:
+        print("Usage: python check_retrieved.py directory/of/pdb_files file.xlsx [sheet index]")
         sys.exit(1)
     
     pdb_directory = sys.argv[1]
     excel_path = sys.argv[2]
+    sheet_index = int(sys.argv[3]) if len(sys.argv) == 4 else None
 
     # Ensure pdb_directory exists
     if not os.path.isdir(pdb_directory):
@@ -16,7 +17,12 @@ def main():
         sys.exit(1)
 
     # Read Excel file
-    df = pd.read_excel(excel_path)
+    if sheet_index is not None:
+        xls = pd.ExcelFile(excel_path)
+        sheet_name = xls.sheet_names[sheet_index]
+        df = pd.read_excel(xls, sheet_name=sheet_name)
+    else:
+        df = pd.read_excel(excel_path)
 
     # Ensure 'id' column exists
     if 'id' not in df.columns:

--- a/retrieve.py
+++ b/retrieve.py
@@ -16,7 +16,7 @@ def retrieve_pdb(uniprot_id, output_dir):
 
 def main():
     if len(sys.argv) < 3 or len(sys.argv) > 4:
-        print("Usage: python retrieval.py /path/proteins.xlsx structure_dir [sheet_index]")
+        print("Usage: python retrieve.py /path/proteins.xlsx structure_dir [sheet_index]")
         sys.exit(1)
     
     excel_path = sys.argv[1]


### PR DESCRIPTION
I added the sheet_index parameter to `check_retrieved.py` analogously to `retrieve.py` to allow for the selection of the sheet in the excel document.
If I've made a mistake and this parameter isn't needed, feel free to delete this pull request.